### PR TITLE
Add test for PR 44335

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -697,12 +697,13 @@ def _virtual(osdata):
         if os.path.isfile('/proc/1/cgroup'):
             try:
                 with salt.utils.fopen('/proc/1/cgroup', 'r') as fhr:
-                    if ':/lxc/' in fhr.read():
-                        grains['virtual_subtype'] = 'LXC'
-                dstrings = (':/system.slice/docker', ':/docker/', ':/docker-ce/')
-                with salt.utils.fopen('/proc/1/cgroup', 'r') as fhr:
                     fhr_contents = fhr.read()
-                    if any(dstring in fhr_contents for dstring in dstrings):
+                if ':/lxc/' in fhr_contents:
+                    grains['virtual_subtype'] = 'LXC'
+                else:
+                    if any(x in fhr_contents
+                           for x in (':/system.slice/docker', ':/docker/',
+                                     ':/docker-ce/')):
                         grains['virtual_subtype'] = 'Docker'
             except IOError:
                 pass


### PR DESCRIPTION
This also modifies the virtual_subtype code slightly, due to an issue I
noticed in testing. We were reading from `/proc/1/cgroup` twice (once
for LXC, and then again for Docker).